### PR TITLE
Limit Python to 3.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ keywords = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "3.7.*"
 loguru = "0.5.3"
 psutil = "*"
 


### PR DESCRIPTION
Hey Dima, this is the syntax you'll need to pin the project to exactly 3.7. `^3.7` means `>=3.7,<4` so newer versions of Python are still compatible.